### PR TITLE
BIC-147: fix forms submission when storage is not available

### DIFF
--- a/docs/forms-interaction-process.md
+++ b/docs/forms-interaction-process.md
@@ -1,0 +1,20 @@
+# BIC-jQM: Forms Interaction Process
+
+This is the Forms-specific process that the InteractionView performs during the
+[navigation process](navigation-process.md).
+
+1. the InteractionView creates a new [FormView](../src/view-form.js)
+
+2. the FormView creates a new [FormActionView](../src/view-form-action.js) if
+  the form is an add, edit, view or delete action
+
+3. the FormActionView retrieves the desired form' definition using
+  `BMP.Forms.getDefinition(name, action)`
+
+4. the FormActionView creates a new [FormControlView](../src/view-form-controls.js)
+
+5. the FormControlView uses a Mustache template to create the save and submit
+  buttons
+
+6. the FormActionView uses the Forms library to initialise, render and populate
+  (if necessary) the desired form

--- a/docs/navigation-process.md
+++ b/docs/navigation-process.md
@@ -1,0 +1,18 @@
+# BIC-jQM: Navigation Process
+
+1. user clicks a hyperlink or button which changes the URL in the location bar
+
+2. jQueryMobile triggers its [pagebeforeload](http://api.jquerymobile.com/1.3/pagebeforeload/)
+  event
+
+3. the [router](../src/router.js) parses the event data in its `routeRequest`
+  method, identifying the destination interaction
+
+4. the `prepareForView` method in the [InteractionModel](../src/model-interaction.js)
+  prepares the data that the view will need, based on the interaction's type
+
+5. the router waits until this is complete, then passes the data to a new
+  [InteractionView](../src/view-interaction.js)
+
+6. InteractionView uses Mustache templates and DOM manipulation to render
+  the content of the interaction to the screen, based on the interaction's type

--- a/docs/pending-queue-process.md
+++ b/docs/pending-queue-process.md
@@ -1,0 +1,26 @@
+# BIC-jQM: Pending Queue Process
+
+1. the user clicks the submit button
+
+2. the click-handler for the submit button is the `formSubmit()` method of the
+  [FormControlView](../src/view-form-controls.js)
+
+3. `formSubmit()` calls the `addToQueue(status)` method, with a status of
+  "Pending" which declares that the form record is ready for submission
+
+    - any other status (e.g. "Draft") saves the form record locally and does not
+      trigger network submission
+
+4. `addToQueue()` retrieves the data from the current form record and stores it
+  along with some form metadata to the `BMP.BIC.pending` Backbone Collection
+
+5. `addToQueue()` calls `BMP.BIC.pending.processQueue()` and then navigates away
+  from the form interaction, allowing the submission to complete in the
+  background
+
+6. the [PendingCollection](../src/collection-pending.js)'s `processQueue()`
+  method identifies all pending items with a "Pending" status and attempts to
+  submit them via the network
+
+7. event handlers created in `addToQueue()` display the successful submission
+  pop-up

--- a/src/main.js
+++ b/src/main.js
@@ -15,15 +15,6 @@ define(
       require(['router', 'auth']);
     }
 
-    // Delay the app for Cordova
-    function init() {
-      if (window.BMP.BlinkGap.isHere()) {
-        window.BMP.BlinkGap.whenReady().then(start, start);
-      } else {
-        start();
-      }
-    }
-
     // Save traditional sync method as ajaxSync
     Backbone.ajaxSync = Backbone.sync;
 
@@ -75,12 +66,21 @@ define(
       return Backbone.ajaxSync;
     };
 
-    // Hook Backbone.sync up to the data layer
-    Backbone.sync = function (method, model, options) {
-      return Backbone.getSyncMethod(model).apply(this, [method, model, options]);
-    };
+    if (app.hasStorage()) {
+      // Hook Backbone.sync up to the data layer
+      Backbone.sync = function (method, model, options) {
+        return Backbone.getSyncMethod(model).apply(this, [method, model, options]);
+      };
+    } else {
+      Backbone.sync = function (method, model, options) { options.success(); };
+    }
 
-    init();
+    if (window.BMP.BlinkGap.isHere()) {
+      // Delay the app for Cordova
+      window.BMP.BlinkGap.whenReady().then(start, start);
+    } else {
+      start();
+    }
 
     return app; // export BMP.BIC
   }

--- a/src/model-application.js
+++ b/src/model-application.js
@@ -289,7 +289,26 @@ define(
             $('#temp').remove();
           });
         });
+      },
+
+      hasStorage: function () {
+        if (typeof Pouch === 'undefined') {
+          return false;
+        }
+        if (window.BMP.BIC.isBlinkGap === true && Pouch.adapters.websql) {
+          return true;
+        }
+        if (Pouch.adapters.idb) {
+          try {
+            return Modernizr.indexeddb && window.indexedDB.open('idbTest', 1).onupgradeneeded === null && navigator.userAgent.indexOf('iPhone') === -1 && navigator.userAgent.indexOf('iPad') === -1;
+          } catch (ignore) {
+            return false;
+          }
+          return false;
+        }
+        return false;
       }
+
     });
 
     window.BMP.BIC3 = new Application();

--- a/src/model-application.js
+++ b/src/model-application.js
@@ -93,18 +93,27 @@ define(
             app.interactions = app.interactions || new InteractionCollection();
             app.datasuitcases = app.datasuitcases || new DataSuitcaseCollection();
             app.forms = app.forms || new FormCollection();
-            app.pending = app.pending || new PendingCollection();
             app.stars = app.stars || new StarsCollection();
             app.formRecords = app.formRecords || new FormRecordsCollection();
 
-            Promise.all([
-              app.interactions.datastore().load(),
-              app.datasuitcases.datastore().load(),
-              app.forms.datastore().load(),
-              app.pending.datastore().load(),
-              app.stars.datastore().load(),
-              app.formRecords.datastore().load()
-            ]).then(resolve, reject);
+            if (app.hasStorage()) {
+              // enable the pending queue
+              app.pending = app.pending || new PendingCollection();
+
+              // prime models / collections with previous persisted data
+              Promise.all([
+                app.interactions.datastore().load(),
+                app.datasuitcases.datastore().load(),
+                app.forms.datastore().load(),
+                app.pending.datastore().load(),
+                app.stars.datastore().load(),
+                app.formRecords.datastore().load()
+              ]).then(resolve, reject);
+
+            } else {
+              resolve();
+            }
+
           });
         });
 

--- a/src/template-form-controls.mustache
+++ b/src/template-form-controls.mustache
@@ -17,10 +17,17 @@
   </div>
   <div data-role="content">
     <h3>Are you sure you want to close this form?</h3>
+    {{#hasStorage}}
     <div data-role="controlgroup" data-type="horizontal" style="width: 100%;">
       <a href="#" id="save" data-role="button" data-rel="save" style="width: 49%;">Save</a>
       <a href="#" id="discard" data-role="button" data-rel="delete" style="width: 49%;">Discard</a>
     </div>
+    {{/hasStorage}}
+    {{^hasStorage}}
+    <div data-role="controlgroup" data-type="horizontal" style="width: 100%;">
+      <a href="#" id="discard" data-role="button" data-rel="delete" style="width: 100%;">Discard</a>
+    </div>
+    {{/hasStorage}}
     <a data-role="button" data-rel="back">Cancel</a>
   </div>
 </div>

--- a/src/view-form-controls.js
+++ b/src/view-form-controls.js
@@ -65,6 +65,14 @@ define(
         view.render();
       },
 
+      formLeave: function () {
+        if (window.BMP.BIC3.history.length === 0) {
+          window.BMP.BIC3.view.home();
+        } else {
+          history.back();
+        }
+      },
+
       formSubmit: function () {
         this.addToQueue('Pending');
       },
@@ -85,16 +93,18 @@ define(
       },
 
       formSave: function (e) {
+        var me = this;
         e.data.view.addToQueue('Draft');
         $('#closePopup').one('popupafterclose', function () {
-          history.back();
+          me.formLeave();
         });
         $('#closePopup').popup('close');
       },
 
       formDiscard: function () {
+        var me = this;
         $('#closePopup').one('popupafterclose', function () {
-          history.back();
+          me.formLeave();
         });
         $('#closePopup').popup('close');
       },
@@ -127,11 +137,7 @@ define(
                   }
                 });
 
-                if (window.BMP.BIC3.history.length === 0) {
-                  window.BMP.BIC3.view.home();
-                } else {
-                  history.back();
-                }
+                view.formLeave();
               }
               resolve(updatedModel);
             };

--- a/src/view-form-controls.js
+++ b/src/view-form-controls.js
@@ -2,6 +2,21 @@ define(
   ['text!template-form-controls.mustache', 'model-application'],
   function (Template, app) {
     'use strict';
+
+    var isHTML = function (string) {
+      var html$;
+      if (!string || typeof string !== 'string' || !string.trim()) {
+        return false;
+      }
+      if (typeof Node === 'undefined' || !Node.TEXT_NODE) {
+        return true; // the string _might_ be HTML, we just can't tell
+      }
+      html$ = $.parseHTML(string);
+      return !html$.every(function (el) {
+        return el.nodeType === Node.TEXT_NODE;
+      });
+    };
+
     var FormControlView = Backbone.View.extend({
 
       events: {
@@ -126,8 +141,12 @@ define(
                     app.view.pendingQueue();
                   } else {
                     model.once('processed', function () {
+                      var result = model.get('result');
                       if (model.get('status') === 'Submitted') {
-                        app.view.popup(model.get('result'));
+                        if (!isHTML(result)) {
+                          data = '<p>' + result + '</p>';
+                        }
+                        app.view.popup(result);
                         model.destroy();
                       } else {
                         app.view.pendingQueue();

--- a/src/view-form-controls.js
+++ b/src/view-form-controls.js
@@ -30,7 +30,9 @@ define(
         var view, options;
 
         view = this;
-        options = {};
+        options = {
+          hasStorage: app.hasStorage()
+        };
 
 
         if (BlinkForms.current.get('pages').length > 1) {
@@ -109,7 +111,6 @@ define(
             }
             app.view.popup(data);
             $('#popup').one('popupafterclose', function () {
-              window.console.log('popupafterclose');
               me.formLeave();
             });
           }, function (jqXHR) {
@@ -147,8 +148,8 @@ define(
         var that = this;
         $('#closePopup').popup({
           afteropen: function (event) {
-            $(event.target).on('click', '#save', {view: that}, that.formSave);
-            $(event.target).on('click', '#discard', {view: that}, that.formDiscard);
+            $(event.target).on('click', '#save', {view: that}, that.formSave.bind(that));
+            $(event.target).on('click', '#discard', {view: that}, that.formDiscard.bind(that));
           },
           afterclose: function (event) {
             $(event.target).off('click', '#save');

--- a/src/view-interaction.js
+++ b/src/view-interaction.js
@@ -438,11 +438,13 @@ define(
       },
 
       popup: function (data) {
+        var popup$;
         this.$el.append(Mustache.render(popupTemplate, {
           contents: data
         }));
-        this.$el.trigger('pagecreate');
-        $('#popup').popup('open');
+        popup$ = $('#popup').popup().popup('open').one('popupafterclose', function () {
+          popup$.remove();
+        });
       },
 
       destroy: function () {

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "assert": true
+  }
+}

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -1,4 +1,5 @@
 /*eslint-disable no-unused-vars*/
+var assert = chai.assert;
 var should = chai.should();
 var expect = chai.expect;
 /*eslint-enable no-unused-vars*/

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -5,12 +5,14 @@ var expect = chai.expect;
 /*eslint-enable no-unused-vars*/
 
 require.config({
-  baseUrl: '/tests/',
+  baseUrl: '/src',
   paths: {
+    implementations: '/tests/implementations',
     feature: '/node_modules/amd-feature/feature',
     geolocation: '/node_modules/geolocation/geolocation',
     Squire: '/node_modules/squirejs/src/Squire',
     pollUntil: '/node_modules/poll-until/poll-until',
+    mustache: '/node_modules/mustache/mustache',
     BlinkGap: '/node_modules/blinkgap-utils/BMP.BlinkGap',
     sinon: '/node_modules/sinon/pkg/sinon',
     text: '/node_modules/text/text'
@@ -47,27 +49,28 @@ require([
   'pollUntil',
   'geolocation',
   'backbone',
+  'mustache',
   'jquery',
   'jquerymobile',
   'feature!es5',
   'BlinkGap',
-  'unit/api-web.js',
-  'unit/collection-datasuitcases.js',
-  'unit/collection-forms.js',
-  'unit/collection-interactions.js',
-  'unit/collection-pending.js',
-  'unit/collection-stars.js',
-  'unit/data-pouch.js',
-  'unit/model-application.js',
-  'unit/model-datasuitcase.js',
-  'unit/model-form.js',
-  'unit/model-interaction.js',
-  'unit/model-pending.js',
-  'unit/model-star.js',
-  'unit/router.js',
-  'unit/view-interaction.js',
-  'unit/view-star.js'
-], function (Promise, pollUntil, geolocation, Backbone) {
+  '/tests/unit/api-web.js',
+  '/tests/unit/collection-datasuitcases.js',
+  '/tests/unit/collection-forms.js',
+  '/tests/unit/collection-interactions.js',
+  '/tests/unit/collection-pending.js',
+  '/tests/unit/collection-stars.js',
+  '/tests/unit/data-pouch.js',
+  '/tests/unit/model-application.js',
+  '/tests/unit/model-datasuitcase.js',
+  '/tests/unit/model-form.js',
+  '/tests/unit/model-interaction.js',
+  '/tests/unit/model-pending.js',
+  '/tests/unit/model-star.js',
+  '/tests/unit/router.js',
+  '/tests/unit/view-interaction.js',
+  '/tests/unit/view-star.js'
+], function (Promise, pollUntil, geolocation, Backbone, Mustache) {
   'use strict';
   var runner, failedTests, logFailure;
 
@@ -87,6 +90,7 @@ require([
     return promise;
   };
 
+  window.Mustache = Mustache;
   window.Promise = window.Promise || Promise;
   window.pollUntil = window.pollUntil || pollUntil;
   window.geolocation = window.geolocation || geolocation;

--- a/tests/unit/model-application.js
+++ b/tests/unit/model-application.js
@@ -1,4 +1,4 @@
-define(['Squire'], function (Squire) {
+define(['Squire', 'BlinkGap'], function (Squire) {
   'use strict';
 
   describe('Model - Application', function () {

--- a/tests/unit/model-application.js
+++ b/tests/unit/model-application.js
@@ -148,11 +148,14 @@ define(['Squire'], function (Squire) {
 
       it('should create a collection for pending items', function (done) {
         model.collections().then(function () {
-          expect(model).to.have.property('pending');
-          expect(model.pending).to.be.an.instanceOf(Backbone.Collection);
+          if (model.hasStorage()) {
+            expect(model).to.have.property('pending');
+            expect(model.pending).to.be.an.instanceOf(Backbone.Collection);
+          } else {
+            expect(model).to.not.have.property('pending');
+          }
           done();
         });
-        model.collections();
       });
 
       it('should create a collection for stars', function (done) {

--- a/tests/unit/model-application.js
+++ b/tests/unit/model-application.js
@@ -298,6 +298,17 @@ define(['Squire'], function (Squire) {
       it('should do things, wonderous things');
     });
 
+    describe('#hasStorage()', function () {
+      it('is a function', function () {
+        assert.isFunction(model.hasStorage);
+      });
+
+      it('returns a Boolean', function () {
+        var result = model.hasStorage();
+        assert.isBoolean(result);
+      });
+    });
+
     after(function () {
       BMP.BlinkGap.isHere = oldIsHere; // fix for PhantomJS
     });

--- a/tests/unit/view-interaction.js
+++ b/tests/unit/view-interaction.js
@@ -16,10 +16,9 @@ define(['Squire'], function (Squire) {
       injector.mock('text!template-form.mustache', 'string');
       injector.mock('text!template-category-list.mustache', 'string');
       injector.mock('text!template-pending.mustache', 'string');
-      injector.mock('text!template-popup.mustache', 'string');
       injector.mock('text!template-clear-confirmation-popup.mustache', 'string');
 
-      injector.require(['../src/view-interaction'], function (required) {
+      injector.require(['view-interaction'], function (required) {
         View = required;
         done();
       });
@@ -49,6 +48,33 @@ define(['Squire'], function (Squire) {
         should.exist(BMP.BIC);
         should.exist(BMP.BIC.view);
         expect(BMP.BIC.view).to.equal(view);
+      });
+
+      describe('view.popup()', function () {
+
+        it('is a function', function () {
+          assert.isFunction(view.popup);
+        });
+
+        it('creates a #popup element', function () {
+          var popup$;
+          var text = 'hello, popup!';
+          view.popup(text);
+          popup$ = $('#popup');
+          assert.lengthOf(popup$, 1);
+          assert.equal(popup$.text().trim(), text);
+        });
+
+        it('#popup element is gone after close', function (done) {
+          var popup$;
+          popup$ = $('#popup');
+          popup$.popup('close');
+          setTimeout(function () {
+            popup$ = $('#popup');
+            assert.lengthOf(popup$, 0);
+            done();
+          }, 1e3);
+        });
       });
     });
 


### PR DESCRIPTION
This PR:
- hides the "save" draft button if there is no storage
- prevents initialisation of the pending queue if there is no storage
- causes the "submit" button to skip the pending queue if there is no storage

Additionally:
- the post-submission pop-up now wraps content in a `<p>` if it is not HTML
- the `BMP.BIC.view.popup(message)` method cleans up after itself to avoid duplicate pop-ups