### PR TITLE
BIC-175 # fix BlinkGap detection so it doesn't kill everything

### DIFF
--- a/src/backbone-fix.js
+++ b/src/backbone-fix.js
@@ -4,7 +4,19 @@ define(function () {
   'use strict';
 
   // Save traditional sync method as ajaxSync
-  Backbone.ajaxSync = Backbone.sync;
+  Backbone.oldSync = Backbone.sync;
+  Backbone.ajaxSync = function (method, model, options) {
+    if (!model || !model.url || options && !options.url) {
+      if (window.console && window.console.warn) {
+        window.console.warn(new TypeError('Backbone.sync() (via AJAX) was called, but model has no URL'));
+      }
+      if (options && typeof options.success === 'function') {
+        options.success();
+      }
+      return null;
+    }
+    return Backbone.oldSync(method, model, options);
+  };
 
   // New sync method
   Backbone.dataSync = function (method, model, options) {

--- a/src/promise-blinkgap.js
+++ b/src/promise-blinkgap.js
@@ -1,10 +1,18 @@
 define(function () {
   'use strict';
 
+  var realPromise; // not jQuery.Deferred, yuck!
+
   if (window.BMP && window.BMP.BlinkGap && window.BMP.BlinkGap.isHere && window.BMP.BlinkGap.isHere()) {
 
+    // convert jQuery.Deferred to an ES6 Promise so we can safely chain it
+    realPromise = Promise.resolve(window.BMP.BlinkGap.whenReady());
+
     /** @type {Promise} always resolved, never rejected */
-    return window.BMP.BlinkGap.whenReady().then(null, function () {
+    return realPromise.then(null, function (err) {
+      if (window.console && window.console.error) {
+        window.console.error('BMP.BlinkGap.whenReady()', err);
+      }
       return Promise.resolve();
     });
   }

--- a/src/promise-indexeddb.js
+++ b/src/promise-indexeddb.js
@@ -5,17 +5,21 @@ define(function (require) {
 
   return whenBlinkGapReady.then(function () {
     return new Promise(function (resolve) {
+      var timeout = false;
       var timer = setTimeout(function () {
         // timer never necessary for actual usage
         // but timer _is_ mysteriously necessary for running the tests in Safari
         if (window.console && window.console.warn) {
           window.console.warn('timeout: IndexedDB tests too slow');
         }
+        timeout = true;
         resolve(false);
-      }, 500);
+      }, 1500); // pick a time under 2sec, which is the default test timeout
       isIndexedDBReliable.quick(function (result) {
-        clearTimeout(timer);
-        resolve(result);
+        if (!timeout) {
+          clearTimeout(timer);
+          resolve(result);
+        }
       });
     });
   });

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -74,6 +74,7 @@ require([
   '/tests/unit/model-interaction.js',
   '/tests/unit/model-pending.js',
   '/tests/unit/model-star.js',
+  '/tests/unit/promise-blinkgap.js',
   '/tests/unit/router.js',
   '/tests/unit/view-interaction.js',
   '/tests/unit/view-star.js',

--- a/tests/unit/promise-blinkgap.js
+++ b/tests/unit/promise-blinkgap.js
@@ -1,0 +1,54 @@
+/*globals define:false, require:false, requirejs:false*/ // Require.js
+/*globals describe:false, it:false, before:false, after:false*/ // Mocha
+/*globals assert:false*/ // Chai
+define(['Squire'], function (Squire) {
+  'use strict';
+
+  var CONTEXT = 'tests/unit/promise-blinkgap.js';
+
+  describe('whenBlinkGapReady', function () {
+
+    var injector, promise;
+
+    before(function (done) {
+      var cfg = JSON.parse(JSON.stringify(requirejs.s.contexts._.config));
+      cfg.context = CONTEXT;
+      require.config(cfg);
+      injector = new Squire(CONTEXT);
+
+      // fake BlinkGap environment for these tests
+      window.isBlinkGap = true;
+      window.cordova = { available: true };
+
+      injector.require(['promise-blinkgap'], function (p) {
+        promise = p;
+        done();
+      });
+    });
+
+    after(function () {
+      injector.remove();
+      window.isBlinkGap = false;
+      delete window.cordova;
+    });
+
+    it('module exports a Promise-like Object', function (done) {
+      assert(promise);
+      assert.isFunction(promise.then);
+      promise.then(function () {
+        done();
+      });
+    });
+
+    it('promise can be chained', function (done) {
+      promise.then(function () {
+        return Promise.resolve('abc');
+      }).then(function (result) {
+        // this fails if promise is a jQuery.Deferred
+        assert.equal(result, 'abc');
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
BIC-154:
- wire up `Backbone.sync` so that it's easier to tell when it's been called improperly
- don't try to use persistence features with the model at `BMP.BIC` because it isn't a persistent model anymore

BIC-175:
- fix the timed promise code so that `resolve()` isn't hit twice
- convert a `jQuery.Deferred` to a real `Promise` to solve chaining problems (caused BlinkGap detection to kill everything during initialisation)