### PR TITLE
BIC-173 # improve Forms pagination controls, make extensible

### DIFF
--- a/src/bic/model-application.js
+++ b/src/bic/model-application.js
@@ -313,5 +313,9 @@ define(function (require) {
 
   singleton.meta = metaStore;
 
+  singleton.views = {
+    FormControls: null
+  };
+
   return singleton;
 });

--- a/src/bic/template/form/controls.mustache
+++ b/src/bic/template/form/controls.mustache
@@ -1,9 +1,25 @@
 {{#pages}}
-<div id="FormPageCount" data-role="controlgroup" data-type="horizontal">
-  <a id="previousFormPage" data-role="button" data-icon="arrow-l" {{^previous}}class="ui-disable"{{/previous}} style="width: 32%" data-iconpos="left">&nbsp;</a>
-  <a data-role="button" style="width: 33%"><span id="currentPage">{{current}}</span> of <span id="totalPages">{{total}}</span></a>
-  <a id="nextFormPage" data-role="button" data-icon="arrow-r" {{^next}}class="ui-disable"{{/next}} style="width: 32%" data-iconpos="right">&nbsp;</a>
-</div>
+  {{^greaterThanTwo}}
+      <div id="FormPageCount" data-role="controlgroup" data-type="horizontal">
+          <a id="previousFormPage" data-role="button" data-icon="arrow-l" {{^previous}}class="ui-disable"{{/previous}} style="width: 32%" data-iconpos="left">&nbsp;</a>
+          <a data-role="button" style="width: 33%"><span id="currentPage">{{current}}</span> of <span id="totalPages">{{total}}</span></a>
+          <a id="nextFormPage" data-role="button" data-icon="arrow-r" {{^next}}class="ui-disable"{{/next}} style="width: 32%" data-iconpos="right">&nbsp;</a>
+      </div>
+  {{/greaterThanTwo}}
+  {{#greaterThanTwo}}
+      <div data-role="controlgroup">
+          <progress min="0" max="{{total}}" value="{{current}}" style="width:100%;">
+            {{current}} / {{total}}
+          </progress>
+      </div>
+      <div id="FormPageCount" data-role="controlgroup" data-type="horizontal">
+          <a id="firstFormPage" data-role="button" {{^previous}}class="ui-disable"{{/previous}} style="width: 16%">&#8676;</a>
+          <a id="previousFormPage" data-role="button" {{^previous}}class="ui-disable"{{/previous}} style="width: 16%">&#8592;</a>
+          <a data-role="button" style="width: 33%"><span id="currentPage">{{current}}</span> of <span id="totalPages">{{total}}</span></a>
+          <a id="nextFormPage" data-role="button" {{^next}}class="ui-disable"{{/next}} style="width: 16%">&#8594;</a>
+          <a id="lastFormPage" data-role="button" {{^next}}class="ui-disable"{{/next}} style="width: 16%">&#8677;</a>
+      </div>
+  {{/greaterThanTwo}}
 {{/pages}}
 
 {{^hasStorage}}

--- a/src/bic/view-form-action.js
+++ b/src/bic/view-form-action.js
@@ -23,10 +23,13 @@ define(function (require) {
         .then(function (definition) {
           var formRecord;
           var pendingModel;
+          var SubView;
+
+          SubView = view.constructor.prepareSubView();
 
           Forms.initialize(definition, view.model.get('blinkFormAction'));
           view.$el.append(Forms.current.$form);
-          view.subView = new FormControls({
+          view.subView = new SubView({
             model: view.model
           });
           view.subView.render();
@@ -62,6 +65,15 @@ define(function (require) {
         });
 
       return view;
+    }
+  }, {
+    prepareSubView: function () {
+      var SubView = FormControls;
+
+      if (app.views.FormControls) {
+        SubView = app.views.FormControls;
+      }
+      return SubView;
     }
   });
 

--- a/src/bic/view-form-controls.js
+++ b/src/bic/view-form-controls.js
@@ -12,7 +12,7 @@ define(function (require) {
 
   // local modules
 
-  var Template = require('text!bic/template-form-controls.mustache');
+  var Template = require('text!bic/template/form/controls.mustache');
   var app = require('bic/model-application');
   var API = require('bic/api');
   var USER_ACTIONS = require('bic/enum-user-actions');
@@ -60,36 +60,67 @@ define(function (require) {
       'click #FormControls #close': 'formClose',
       'click #FormControls #save': 'formSave2',
       'click #nextFormPage': 'nextFormPage',
-      'click #previousFormPage': 'previousFormPage'
+      'click #previousFormPage': 'previousFormPage',
+      'click #firstFormPage': 'firstFormPage',
+      'click #lastFormPage': 'lastFormPage'
     },
 
     render: function () {
       var view, options;
-
+      var pages, index;
       view = this;
       options = {
         hasStorage: app.hasStorage()
       };
 
       if (Forms.current.get('pages').length > 1) {
+        pages = Forms.current.get('pages');
+        index = pages.current.index();
         options.pages = {
-          current: Forms.current.get('pages').current.index() + 1,
-          total: Forms.current.get('pages').length
+          current: index + 1,
+          total: pages.length,
+          greaterThanTwo: pages.length > 2
         };
 
-        if (Forms.current.get('pages').current.index() !== 0) {
+        if (pages.current.index() !== 0) {
           options.pages.previous = true;
         }
 
-        if (Forms.current.get('pages').current.index() !== Forms.current.get('pages').length - 1) {
+        if (pages.current.index() !== pages.length - 1) {
           options.pages.next = true;
         }
       }
 
-      view.$el.html(Mustache.render(Template, options));
+      view.$el.html(Mustache.render(view.constructor.template, options));
       $.mobile.activePage.trigger('pagecreate');
 
       return view;
+    },
+
+    firstFormPage: function () {
+      var view, index;
+
+      view = this;
+      index = Forms.current.get('pages').current.index();
+
+      if (index > 0) {
+        Forms.current.get('pages').goto(0);
+        view.render();
+      }
+    },
+
+    lastFormPage: function () {
+      var view, index, len;
+
+      view = this;
+      len = Forms.current.get('pages').length;
+      index = Forms.current.get('pages').current.index();
+
+      //only move and render if required
+      if (index < len - 1) {
+        Forms.current.get('pages').goto(len - 1);
+        view.render();
+      }
     },
 
     nextFormPage: function () {
@@ -345,6 +376,8 @@ define(function (require) {
         });
       });
     }
+  }, {
+    template: Template
   });
 
   return FormControlView;

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -73,6 +73,7 @@ require([
   '/tests/unit/router.js',
   '/tests/unit/view-interaction.js',
   '/tests/unit/view-star.js',
+  '/tests/unit/view-form-action.js',
   '/tests/unit/view-form-controls.js'
 ], function (Backbone, Promise) {
   'use strict';

--- a/tests/unit/view-form-action.js
+++ b/tests/unit/view-form-action.js
@@ -1,0 +1,58 @@
+define(['Squire', 'backbone'], function (Squire, Backbone) {
+  'use strict';
+
+  var CONTEXT = 'tests/unit/view-form-action.js';
+
+  describe('View - Form Actions ', function () {
+    var injector, View;
+    var mockApp;
+    var mockControls;
+
+    before(function (done) {
+      var cfg = JSON.parse(JSON.stringify(requirejs.s.contexts._.config));
+      cfg.context = CONTEXT;
+      require.config(cfg);
+      injector = new Squire(CONTEXT);
+
+      mockApp = new Backbone.Model();
+      mockControls = new Backbone.Model();
+
+      mockApp.views = {
+        FormControls: null
+      };
+
+      // import global `require('dep')` into local `injector.require('dep')`
+      injector.mock('backbone', Backbone);
+
+      injector.mock('bic/model-application', mockApp);
+      injector.mock('bic/view-form-controls', mockControls);
+      injector.require(['bic/view-form-action'], function (required) {
+        View = required;
+        done();
+      });
+    });
+
+    after(function () {
+      injector.remove();
+    });
+
+    it('should exist', function () {
+      should.exist(View);
+    });
+
+    it('should be a Backbone.View object constructor', function () {
+      View.should.be.an.instanceOf(Function);
+    });
+
+    describe('prepareSubView', function () {
+      it('functions on view', function () {
+        assert(mockControls === View.prepareSubView());
+        mockApp.views.FormControls = new Backbone.Model();
+        assert(mockApp.views.FormControls === View.prepareSubView());
+        assert(mockControls !== View.prepareSubView());
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
- BMP.BIC.views.FormControls: location override default form control view
- view-form-action: added prepareSubView method that checks to see above setting to decide which view to use
- view-form-controls: added last/first page functions
- moved template to folder + added template part for first/last pagination buttons
- added tests to confirm next/previous/first/last button functions work correctly
- added prepareSubView works as expected